### PR TITLE
Update ReactNativeFirebaseMessagingHeadlessService.java

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingHeadlessService.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingHeadlessService.java
@@ -1,10 +1,26 @@
 package io.invertase.firebase.messaging;
 
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.AlarmManager;
+import android.app.KeyguardManager;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.PixelFormat;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.Window;
+import android.view.WindowManager.LayoutParams;
+import android.view.WindowManager;
+
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 import com.google.firebase.messaging.RemoteMessage;
+
+import java.sql.Time;
+import java.util.concurrent.TimeUnit;
+
 import io.invertase.firebase.common.ReactNativeFirebaseJSON;
 
 import javax.annotation.Nullable;
@@ -13,14 +29,14 @@ public class ReactNativeFirebaseMessagingHeadlessService extends HeadlessJsTaskS
   private static final long TIMEOUT_DEFAULT = 60000;
   private static final String TIMEOUT_JSON_KEY = "messaging_android_headless_task_timeout";
   private static final String TASK_KEY = "ReactNativeFirebaseMessagingHeadlessTask";
-
+  public  static  Activity activity;
   @Override
   protected @Nullable
   HeadlessJsTaskConfig getTaskConfig(Intent intent) {
     Bundle extras = intent.getExtras();
     if (extras == null) return null;
     RemoteMessage remoteMessage = intent.getParcelableExtra("message");
-
+    ShowWhenLockApp(intent);
     return new HeadlessJsTaskConfig(
       TASK_KEY,
       ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap(remoteMessage),
@@ -30,4 +46,43 @@ public class ReactNativeFirebaseMessagingHeadlessService extends HeadlessJsTaskS
       true
     );
   }
+  //Auto open app when app closed, killed, or device locked.
+  // Create function onCreate on MainActivity.java
+  // setFags to accecpt app open over lock screen.
+  // activity.getWindow().addFlags(
+  // WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON|
+  // WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD|
+  // WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCED|
+  // WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+  // )
+  @SuppressLint("WrongConstant")
+  private void ShowWhenLockApp(Intent myIntent){
+    try {
+      KeyguardManager myKM = (KeyguardManager) getBaseContext().getSystemService(Context.KEYGUARD_SERVICE);
+      if( myKM.inKeyguardRestrictedInputMode()) {
+        Log.e("Check lock","DEVICE LOCK");
+        PackageManager packageManager = getApplicationContext().getPackageManager();
+        Intent launchIntent = packageManager.getLaunchIntentForPackage("com.checkserver");
+        launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        launchIntent.addFlags(
+          WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED +
+            WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD +
+            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON +
+            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+          getApplicationContext().startActivity(launchIntent);
+      } else {
+        //it is not locked
+        Log.e("Check lock","DEVICE NOT LOCK");
+        PackageManager packageManager = getApplicationContext().getPackageManager();
+        Intent launchIntent = packageManager.getLaunchIntentForPackage("com.checkserver");
+        getApplicationContext().startActivity(launchIntent);
+      }
+    }
+    catch (Exception e){
+      Log.e("error",e.getMessage());
+    }
+  }
+
 }
+
+


### PR DESCRIPTION
Set auto open app when app closed, killer or device locked.

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
